### PR TITLE
fix: Update CHANGELOG before PR creation

### DIFF
--- a/memory/release-process/changelog-workflow.md
+++ b/memory/release-process/changelog-workflow.md
@@ -1,0 +1,51 @@
+# CHANGELOG Workflow Memory
+
+## 2025-08-09: CHANGELOG Before PR Creation Process
+**Context:** BUG-010-PRB-001
+**Problem:** CHANGELOG updates were happening after PR creation, reducing review visibility
+**Solution:** Enforce CHANGELOG update before PR creation in git operations workflow
+**Process:**
+1. Update CHANGELOG with release notes
+2. Bump VERSION file if applicable
+3. Commit both files together
+4. Create PR with complete changelog visibility
+5. Merge PR
+6. Create GitHub release using CHANGELOG content
+
+**Code:** Added to prb-execution.md git operations validation:
+```markdown
+[ ] CHANGELOG updated before PR creation (if release changes)
+[ ] Version bumped in same commit as CHANGELOG (if applicable)
+```
+
+**Benefits:**
+- Improved review visibility of changes
+- Complete release documentation before PR
+- Better changelog quality through review process
+- Consistent release workflow enforcement
+
+**Integration:** Enforced through PRB execution behavior patterns
+
+---
+
+## Process Order Documentation
+
+**CRITICAL SEQUENCE for Release PRBs:**
+1. **Update CHANGELOG** - Add release notes for current version
+2. **Bump VERSION** - Update version numbers in applicable files
+3. **Commit Together** - Single commit with both CHANGELOG and VERSION changes
+4. **Create PR** - Pull request shows complete changelog in review
+5. **Review Process** - Reviewers see full context of changes
+6. **Merge PR** - Changes integrated with complete documentation
+7. **GitHub Release** - Create release using CHANGELOG content
+
+**Anti-Pattern (Previous):**
+- Create PR first
+- Update CHANGELOG later
+- Reduced review visibility
+- Incomplete release documentation
+
+**Enforcement Location:** 
+- src/behaviors/prb-execution.md
+- Git Operations Validation checklist
+- Mandatory PRB section execution requirements

--- a/src/behaviors/prb-execution.md
+++ b/src/behaviors/prb-execution.md
@@ -41,7 +41,7 @@ TASK TOOL VALIDATION (MANDATORY FIRST CHECK):
 MANDATORY PRB SECTION EXECUTION:
 ☐ 1. Complete Context Section - ALL file references validated, settings loaded
 ☐ 2. Requirements Section - EVERY functional/processual/technical requirement met
-☐ 3. Git Operations Section - EVERY command executed exactly as specified
+☐ 3. Git Operations Section - EVERY command executed exactly as specified (CHANGELOG before PR creation)
 ☐ 4. Knowledge Management Section - ALL learnings captured in specified paths
 ☐ 5. Review Process Section - ALL reviewers complete their reviews
 ☐ 6. Implementation Samples Section - Applied correctly with examples
@@ -283,6 +283,8 @@ ExecuteProjectScopeValidation(prb_context):
 ### Git Operations Validation
 ```markdown
 ## Git Operations ✓
+[ ] CHANGELOG updated before PR creation (if release changes)
+[ ] Version bumped in same commit as CHANGELOG (if applicable)
 [ ] All changes staged properly
 [ ] Commit messages follow privacy requirements
 [ ] Branch operations completed


### PR DESCRIPTION
## Summary
- Adds CHANGELOG update enforcement to PRB execution behavior
- Ensures release documentation is complete before PRs
- Improves review visibility and process clarity

## Changes
- Updated prb-execution.md with CHANGELOG requirements
- Created memory entry documenting the release workflow
- Enforces CHANGELOG+VERSION update before PR creation

## Testing
- PRB execution now validates CHANGELOG updates
- Git operations checklist includes CHANGELOG step
- Process documented in memory for future reference

Fixes BUG-010